### PR TITLE
specify fine-grained dependencies for grpc

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,6 +3,8 @@ import com.trueaccord.scalapb.{ScalaPbPlugin => PB}
 // https://github.com/grpc/grpc-java/blob/v0.13.2/examples/build.gradle#L32
 val json = libraryDependencies += "org.glassfish" % "javax.json" % "1.0.4"
 
+val grpcVersion = "0.14.0"
+
 val unusedWarnings = (
   "-Ywarn-unused" ::
   "-Ywarn-unused-import" ::
@@ -24,7 +26,10 @@ lazy val grpcScalaSample = project.in(file("grpc-scala")).settings(
     com.github.os72.protocjar.Protoc.runProtoc("-v300" +: args.toArray)
   },
   version in PB.protobufConfig := "3.0.0-beta-2",
-  libraryDependencies += "com.trueaccord.scalapb" %% "scalapb-runtime-grpc" % (PB.scalapbVersion in PB.protobufConfig).value,
+  libraryDependencies ++= Seq(
+    "com.trueaccord.scalapb" %% "scalapb-runtime-grpc" % (PB.scalapbVersion in PB.protobufConfig).value,
+    "io.grpc" % "grpc-netty" % grpcVersion //dependency on the netty transport. Use grpc-okhttp for android.
+  ),
   json,
   unmanagedResourceDirectories in Compile += (baseDirectory in LocalRootProject).value / "grpc-java/examples/src/main/resources",
   sourceDirectory in PB.protobufConfig := (baseDirectory in LocalRootProject).value / "grpc-java/examples/src/main/proto",
@@ -47,7 +52,8 @@ lazy val grpcScalaSample = project.in(file("grpc-scala")).settings(
 lazy val grpcJavaSample = project.in(file("grpc-java/examples")).settings(
   commonSettings,
   json,
-  libraryDependencies += "io.grpc" % "grpc-all" % "0.13.2",
+  //this is a dependency for the grpc aggregation project
+  libraryDependencies += "io.grpc" % "grpc-all" % grpcVersion,
   autoScalaLibrary := false,
   unmanagedSourceDirectories in Compile += baseDirectory.value / "src/generated/main/"
 )

--- a/project/plugin.sbt
+++ b/project/plugin.sbt
@@ -1,3 +1,3 @@
-addSbtPlugin("com.trueaccord.scalapb" % "sbt-scalapb" % "0.5.26")
+addSbtPlugin("com.trueaccord.scalapb" % "sbt-scalapb" % "0.5.27")
 
 libraryDependencies += "com.github.os72" % "protoc-jar" % "3.0.0-b2"


### PR DESCRIPTION
To support changes in https://github.com/trueaccord/ScalaPB/pull/114

Do not merge it before 0.5.27 is released.
